### PR TITLE
Generate block attributes with get_block_wrapper_attributes for consistency, Fixes #4

### DIFF
--- a/inc/block-library/donation-form/block.php
+++ b/inc/block-library/donation-form/block.php
@@ -59,9 +59,13 @@ function render_block(array $attributes): string {
 
 	$headingLevel = 'h' . $attributes['headingLevel'];
 
+	$wrapper_attributes = \get_block_wrapper_attributes( [
+		'class' => 'fundraising-form-wrapper',
+	] );
+
 	\ob_start();
 	?>
-	<div class="fundraising-form-wrapper wp-block-fundraising-form">
+	<div <?php echo $wrapper_attributes; ?>>
 		<?php if ( !empty($attributes['title'])) : ?>
 			<?php echo "<$headingLevel class='fundraising-form-wrapper__title'>"; ?>
 				<?php echo \wp_kses( $attributes['title'], $allowed_html ); ?>


### PR DESCRIPTION
Related to issue #4 

Using `get_block_wrapper_attributes()` is the correct way to generate block attributes. This will both fix the difference in naming (#4) and include additional attributes, e.g. if the block has support for colors, typography etc.