### PR TITLE
Remove unnecessary wrapper around editor elements

### DIFF
--- a/inc/block-library/donation-form/src/edit.js
+++ b/inc/block-library/donation-form/src/edit.js
@@ -100,14 +100,12 @@ export default function Edit( { attributes, setAttributes, className } ) {
 	if ( ! apiToken ) {
 		return (
 			<div { ...useBlockProps() }>
-				<div className={ className }>
-					<p>
-						{ __(
-							'Please set an API Token on the plugin settings page.',
-							'fundraising',
-						) }
-					</p>
-				</div>
+				<p>
+					{ __(
+						'Please set an API Token on the plugin settings page.',
+						'fundraising',
+					) }
+				</p>
 			</div>
 		);
 	}
@@ -125,7 +123,7 @@ export default function Edit( { attributes, setAttributes, className } ) {
 				</BlockControls>
 			) }
 
-			<div className={ className }>
+			<>
 				<RichText
 					label={ __( 'Title', 'fundraising' ) }
 					value={ title }
@@ -164,7 +162,7 @@ export default function Edit( { attributes, setAttributes, className } ) {
 				{ ! isLoaded && <p>{ __( 'Loading…', 'fundraising' ) }</p> }
 
 				{ error && <p>{ 'Error: ' + error }</p> }
-			</div>
+			</>
 		</div>
 	);
 	/* eslint-enable react-hooks/rules-of-hooks */


### PR DESCRIPTION
There is an extra wrapping div around the block elements in the editor that is not present when rendering frontend. This confuses the styling, especially when extending T2 Block Margin to handle the internal spacing in the donation form block.

I suggest we remove this wrapper.

<img width="230" alt="Screenshot 2024-05-30 at 12 23 59" src="https://github.com/DekodeInteraktiv/fundraising-extension-wp/assets/16900754/46dd7047-dab5-4f84-8dc7-446b8a5dc635">
