### PR TITLE
Use same class names for block internals in frontend and editor

### DIFF
--- a/inc/block-library/donation-form/src/edit.js
+++ b/inc/block-library/donation-form/src/edit.js
@@ -129,6 +129,7 @@ export default function Edit( { attributes, setAttributes, className } ) {
 				<RichText
 					label={ __( 'Title', 'fundraising' ) }
 					value={ title }
+					className="fundraising-form-wrapper__title"
 					onChange={ ( value ) => setAttributes( { title: value } ) }
 					placeholder={ __( 'Title…', 'fundraising' ) }
 					tagName={ tagName }
@@ -139,6 +140,7 @@ export default function Edit( { attributes, setAttributes, className } ) {
 				<RichText
 					label={ __( 'Description', 'fundraising' ) }
 					value={ description }
+					className="fundraising-form-wrapper__desc"
 					onChange={ ( value ) =>
 						setAttributes( { description: value } )
 					}
@@ -156,6 +158,7 @@ export default function Edit( { attributes, setAttributes, className } ) {
 				<ComboboxControl
 					label={ __( 'Select a form', 'fundraising' ) }
 					value={ formId }
+					className="fundraising-form"
 					options={ forms ? forms : [ { label: '', value: '' } ] }
 					onChange={ ( value ) => setAttributes( { formId: value } ) }
 					disabled={ ! isLoaded }


### PR DESCRIPTION
For a consistent design experience, It's usually smart to use the same class names for block internals in editor and frontend.