### PR TITLE
Append extra button class to inherit default button styling for WP

### DIFF
--- a/inc/block-library/donation-form/block.php
+++ b/inc/block-library/donation-form/block.php
@@ -81,6 +81,7 @@ function render_block(array $attributes): string {
 			data-form-id="<?php echo \esc_attr( $attributes['formId'] ); ?>"
 			data-env="<?php echo \wp_get_environment_type(); ?>"
 			data-lang="<?php echo \esc_attr( \get_locale() ); ?>"
+			data-button-classes="wp-element-button"
 		></div>
 	</div>
 	<?php


### PR DESCRIPTION
As discussed on Slack regarding using default button styling for donation for buttons.