### PR TITLE
Fix FUNDY_CORE_URL env var instantiation

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -30,8 +30,8 @@ if ( ! \defined( 'ABSPATH' ) ) {
  * variable and if not default to production URL.
  */
 if ( ! \defined( 'FUNDY_CORE_URL' ) ) {
-	if ( \function_exists( 'env' ) ) {
-		\define( 'FUNDY_CORE_URL', \env( 'FUNDY_CORE_URL', 'https://fundy.cloud/' ) );
+	if ( \function_exists( 'env' ) && ! empty( \env( 'FUNDY_CORE_URL' ) ) {
+		\define( 'FUNDY_CORE_URL', \env( 'FUNDY_CORE_URL' ) );
 	} else {
 		\define( 'FUNDY_CORE_URL', 'https://fundy.cloud/' );
 	}


### PR DESCRIPTION
The `env()` function does not allow a second parameter to set a default value for the desired env variable.
This results in the `FUNDY_CORE_URL` constant being empty on "default" WP installations, until you set the `FUNDY_CORE_URL` var in your `.env` file.

This fixes it so the default is properly set.