### PR TITLE
Bugfix/NGO-951/Preload Assets

### DIFF
--- a/inc/head.php
+++ b/inc/head.php
@@ -19,6 +19,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
  * Hooks
  */
 \add_filter( 'wp_resource_hints', __NAMESPACE__ . '\\add_dns_prefetch', 10, 2 );
+\add_filter('wp_preload_resources', __NAMESPACE__ . '\\add_resource_preload' );
 
 /**
  * Add DNS prefetch.
@@ -26,7 +27,71 @@ if ( ! \defined( 'ABSPATH' ) ) {
 function add_dns_prefetch( array $hints, string $relation_type ): array {
 	if ( 'preconnect' === $relation_type ) {
 		$hints[] = get_base_url();
+		$hints[] = 'https://assets.fundy.cloud';
 	}
 
 	return $hints;
+}
+
+/**
+ * Add script preload.
+ */
+function add_resource_preload( array $resources ): array {
+	$resources[] = [
+		'href'        => 'https://assets.fundy.cloud/fundy-forms.latest.js',
+		'as'          => 'script',
+		'crossorigin' => 'anonymous',
+	];
+
+	foreach ( get_current_post_form_ids() as $form_id ) {
+		$resources[] = [
+			'href'        => get_base_url() . '/api/v1/form/schema/' . $form_id,
+			'as'          => 'fetch',
+			'crossorigin' => 'anonymous',
+		];
+	}
+
+	return $resources;
+}
+
+/**
+ * Collect form IDs from donation-form blocks in the current singular post.
+ *
+ * @return int[]
+ */
+function get_current_post_form_ids(): array {
+	if ( ! \is_singular() ) {
+		return [];
+	}
+
+	$post = \get_post();
+	if ( ! $post instanceof \WP_Post || ! \has_blocks( $post->post_content ) ) {
+		return [];
+	}
+
+	$form_ids = [];
+	collect_donation_form_ids( \parse_blocks( $post->post_content ), $form_ids );
+
+	return \array_values( \array_unique( $form_ids ) );
+}
+
+/**
+ * Walk parsed blocks recursively and collect donation-form IDs.
+ *
+ * @param array $blocks   Parsed blocks.
+ * @param int[] $form_ids Accumulator, passed by reference.
+ */
+function collect_donation_form_ids( array $blocks, array &$form_ids ): void {
+	foreach ( $blocks as $block ) {
+		if ( 'fundy/donation-form' === ( $block['blockName'] ?? '' ) ) {
+			$form_id = (int) ( $block['attrs']['formId'] ?? 0 );
+			if ( $form_id > 0 ) {
+				$form_ids[] = $form_id;
+			}
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			collect_donation_form_ids( $block['innerBlocks'], $form_ids );
+		}
+	}
 }


### PR DESCRIPTION
Adds preload for both the JS and the form schema request.

**DOES NOT WORK**

For the form schema preload to work, the request needs to be made in the the **exact** same way (request headers, URL, etc). For us the cache busting URL params make this impossible. Looping through the content also does not catch everything which could be included via FSE these days (patterns/etc).

**PERFORMANCE ISSUE**

We can only add the preload for the form schema by looping through post content in the header. This means that the site needs to loop through the content twice to render the post, which will have a negative performance impact.

**IDEAS**

I am not sure how to rescue this, but I have a few thoughts.

1) Only preload the main JS script. Minor improvement.
2) We could update post meta with a list of Form IDs updated on save, instead of looping through content. Not sure if we could make this fully compatible with FSE?