### PR TITLE
Bugfix/NGO-951/Earlier Script Loading

### DIFF
--- a/dekode-fundraising.php
+++ b/dekode-fundraising.php
@@ -28,7 +28,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
 \define( 'FUNDY_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );
 \define( 'FUNDY_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'FUNDY_MIN_PHP_VERSION', '8.0' );
-\define( 'FUNDY_MIN_WP_VERSION', '6.0' );
+\define( 'FUNDY_MIN_WP_VERSION', '6.4' );
 
 /**
  * Define the Core URL.

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -24,7 +24,8 @@ if ( ! \defined( 'ABSPATH' ) ) {
  * Hooks
  */
 \add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\register_assets' );
-\add_filter( 'style_loader_tag', __NAMESPACE__ . '\\add_form_style_fetch_priority', 10, 2 );
+\add_filter( 'style_loader_tag', __NAMESPACE__ . '\\add_form_style_attrs', 10, 2 );
+\add_filter( 'script_loader_tag', __NAMESPACE__ . '\\add_form_script_attrs', 10, 2 );
 
 /**
  * Register all assets.
@@ -135,19 +136,47 @@ function register_form_assets(): void {
 }
 
 /**
- * Add fetchpriority="high" to the form stylesheet tag so it matches the
- * preload hint and isn't deprioritised behind other render-blocking CSS.
+ * Add fetchpriority="high" and crossorigin="anonymous" to the form stylesheet
+ * tag so it matches the preload hint (same priority and credentials mode) and
+ * isn't deprioritised behind other render-blocking CSS.
  */
-function add_form_style_fetch_priority( string $tag, string $handle ): string {
+function add_form_style_attrs( string $tag, string $handle ): string {
 	if ( 'fundy-form-style' !== $handle ) {
 		return $tag;
 	}
 
-	if ( false !== \strpos( $tag, 'fetchpriority=' ) ) {
+	$attrs = '';
+
+	if ( false === \strpos( $tag, 'fetchpriority=' ) ) {
+		$attrs .= 'fetchpriority="high" ';
+	}
+
+	if ( false === \strpos( $tag, 'crossorigin=' ) ) {
+		$attrs .= 'crossorigin="anonymous" ';
+	}
+
+	if ( '' === $attrs ) {
 		return $tag;
 	}
 
-	return \str_replace( '<link ', '<link fetchpriority="high" ', $tag );
+	return \str_replace( '<link ', '<link ' . $attrs, $tag );
+}
+
+/**
+ * Add crossorigin="anonymous" to the form script tag so its credentials mode
+ * matches the preload hint, allowing the browser to reuse the preloaded
+ * response instead of issuing a second request.
+ */
+function add_form_script_attrs( string $tag, string $handle ): string {
+	if ( 'fundy-form-script' !== $handle ) {
+		return $tag;
+	}
+
+	if ( false !== \strpos( $tag, 'crossorigin=' ) ) {
+		return $tag;
+	}
+
+	return \str_replace( '<script ', '<script crossorigin="anonymous" ', $tag );
 }
 
 /**

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -25,7 +25,6 @@ if ( ! \defined( 'ABSPATH' ) ) {
  */
 \add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\register_assets' );
 \add_filter( 'style_loader_tag', __NAMESPACE__ . '\\add_form_style_attrs', 10, 2 );
-\add_filter( 'script_loader_tag', __NAMESPACE__ . '\\add_form_script_attrs', 10, 2 );
 
 /**
  * Register all assets.
@@ -136,47 +135,26 @@ function register_form_assets(): void {
 }
 
 /**
- * Add fetchpriority="high" and crossorigin="anonymous" to the form stylesheet
- * tag so it matches the preload hint (same priority and credentials mode) and
- * isn't deprioritised behind other render-blocking CSS.
+ * Add fetchpriority="high" to the form stylesheet tag so it matches the
+ * preload hint and isn't deprioritised behind other render-blocking CSS.
  */
 function add_form_style_attrs( string $tag, string $handle ): string {
 	if ( 'fundy-form-style' !== $handle ) {
 		return $tag;
 	}
 
-	$attrs = '';
-
-	if ( false === \strpos( $tag, 'fetchpriority=' ) ) {
-		$attrs .= 'fetchpriority="high" ';
-	}
-
-	if ( false === \strpos( $tag, 'crossorigin=' ) ) {
-		$attrs .= 'crossorigin="anonymous" ';
-	}
-
-	if ( '' === $attrs ) {
+	if ( false !== \strpos( $tag, 'fetchpriority=' ) ) {
 		return $tag;
 	}
 
-	return \str_replace( '<link ', '<link ' . $attrs, $tag );
-}
-
-/**
- * Add crossorigin="anonymous" to the form script tag so its credentials mode
- * matches the preload hint, allowing the browser to reuse the preloaded
- * response instead of issuing a second request.
- */
-function add_form_script_attrs( string $tag, string $handle ): string {
-	if ( 'fundy-form-script' !== $handle ) {
-		return $tag;
-	}
-
-	if ( false !== \strpos( $tag, 'crossorigin=' ) ) {
-		return $tag;
-	}
-
-	return \str_replace( '<script ', '<script crossorigin="anonymous" ', $tag );
+	// Target the <link ...> that carries href=... — avoids matching other
+	// <link markup a previous filter may have prepended.
+	return (string) \preg_replace(
+		'/<link\b([^>]*\bhref=)/',
+		'<link fetchpriority="high"$1',
+		$tag,
+		1
+	);
 }
 
 /**
@@ -186,23 +164,37 @@ function add_form_script_attrs( string $tag, string $handle ): string {
  * and the fundy/donation-form block. Sites that render the form via widgets,
  * template parts, or custom templates can force on via the
  * `fundy/load_form_assets_in_head` filter.
+ *
+ * Detection is memoised for the lifetime of the current main query because
+ * this runs on both `wp_enqueue_scripts` and `wp_preload_resources`. The
+ * cache is keyed on the WP_Query instance so it invalidates automatically
+ * when the query changes (including `go_to()` in the test suite). The filter
+ * is re-applied on every call so late-registered filters still take effect.
  */
 function should_load_form_assets_in_head(): bool {
-	$should_load = false;
+	static $detected   = null;
+	static $last_query = null;
 
-	if ( \is_singular() ) {
-		$post = \get_post();
+	$query = $GLOBALS['wp_query'] ?? null;
 
-		if ( $post ) {
-			$content = (string) $post->post_content;
+	if ( null === $detected || $query !== $last_query ) {
+		$last_query = $query;
+		$detected   = false;
 
-			if ( \has_shortcode( $content, 'fundy_form' ) || \has_block( 'fundy/donation-form', $content ) ) {
-				$should_load = true;
+		if ( \is_singular() ) {
+			$post = \get_post();
+
+			if ( $post ) {
+				$content = (string) $post->post_content;
+
+				if ( \has_shortcode( $content, 'fundy_form' ) || \has_block( 'fundy/donation-form', $content ) ) {
+					$detected = true;
+				}
 			}
 		}
 	}
 
-	return (bool) \apply_filters( 'fundy/load_form_assets_in_head', $should_load );
+	return (bool) \apply_filters( 'fundy/load_form_assets_in_head', $detected );
 }
 
 /**

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -24,6 +24,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
  * Hooks
  */
 \add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\register_assets' );
+\add_filter( 'style_loader_tag', __NAMESPACE__ . '\\add_form_style_fetch_priority', 10, 2 );
 
 /**
  * Register all assets.
@@ -91,19 +92,88 @@ function build_fundy_config(): array {
 /**
  * Register form scripts and styles.
  *
+ * When the form is detected on the current page, the script is registered with
+ * `in_footer => false` and enqueued immediately so it is printed in <head>.
+ * The shortcode and block `viewScript` auto-enqueue act as safety nets for
+ * cases detection can't reach (widgets, template parts, etc.) — those paths
+ * fall through to the footer as before.
+ *
  * @return void
  */
 function register_form_assets(): void {
-	$env    = get_forms_script_env();
-	$suffix = ( 'prod' === $env ) ? 'latest' : 'development';
+	$env          = get_forms_script_env();
+	$suffix       = ( 'prod' === $env ) ? 'latest' : 'development';
+	$load_in_head = should_load_form_assets_in_head();
 
 	if ( ! \wp_script_is( 'fundy-form-script', 'registered' ) ) {
-		\wp_register_script( 'fundy-form-script', "https://assets.fundy.cloud/fundy-forms.{$suffix}.js", [ 'fundy-config' ], null, true );
+		\wp_register_script(
+			'fundy-form-script',
+			"https://assets.fundy.cloud/fundy-forms.{$suffix}.js",
+			[ 'fundy-config' ],
+			null,
+			[
+				'in_footer'     => ! $load_in_head,
+				'strategy'      => 'defer',
+				'fetchpriority' => 'high',
+			]
+		);
 	}
 
-	if ( \apply_filters( 'fundy/enqueue/form_styles', true ) && ! \wp_style_is( 'fundy-form-style', 'registered' ) ) {
+	$enqueue_styles = \apply_filters( 'fundy/enqueue/form_styles', true );
+
+	if ( $enqueue_styles && ! \wp_style_is( 'fundy-form-style', 'registered' ) ) {
 		\wp_register_style( 'fundy-form-style', "https://assets.fundy.cloud/fundy-forms.{$suffix}.css", [], null, 'all' );
 	}
+
+	if ( $load_in_head ) {
+		\wp_enqueue_script( 'fundy-form-script' );
+
+		if ( $enqueue_styles ) {
+			\wp_enqueue_style( 'fundy-form-style' );
+		}
+	}
+}
+
+/**
+ * Add fetchpriority="high" to the form stylesheet tag so it matches the
+ * preload hint and isn't deprioritised behind other render-blocking CSS.
+ */
+function add_form_style_fetch_priority( string $tag, string $handle ): string {
+	if ( 'fundy-form-style' !== $handle ) {
+		return $tag;
+	}
+
+	if ( false !== \strpos( $tag, 'fetchpriority=' ) ) {
+		return $tag;
+	}
+
+	return \str_replace( '<link ', '<link fetchpriority="high" ', $tag );
+}
+
+/**
+ * Determine whether the form assets are needed on the current page.
+ *
+ * Detection checks the queried singular post for the [fundy_form] shortcode
+ * and the fundy/donation-form block. Sites that render the form via widgets,
+ * template parts, or custom templates can force on via the
+ * `fundy/load_form_assets_in_head` filter.
+ */
+function should_load_form_assets_in_head(): bool {
+	$should_load = false;
+
+	if ( \is_singular() ) {
+		$post = \get_post();
+
+		if ( $post ) {
+			$content = (string) $post->post_content;
+
+			if ( \has_shortcode( $content, 'fundy_form' ) || \has_block( 'fundy/donation-form', $content ) ) {
+				$should_load = true;
+			}
+		}
+	}
+
+	return (bool) \apply_filters( 'fundy/load_form_assets_in_head', $should_load );
 }
 
 /**
@@ -121,7 +191,17 @@ function register_conversion_script(): void {
 	$src    = \apply_filters( 'fundy/conversion_script_src', "https://assets.fundy.cloud/fundy-conversion.{$suffix}.js", $env );
 
 	if ( ! \wp_script_is( 'fundy-conversion-script', 'registered' ) ) {
-		\wp_register_script( 'fundy-conversion-script', $src, [ 'fundy-config' ], null, true );
+		\wp_register_script(
+			'fundy-conversion-script',
+			$src,
+			[ 'fundy-config' ],
+			null,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+				'fetchpriority' => 'low',
+			]
+		);
 	}
 
 	\wp_enqueue_script( 'fundy-conversion-script' );
@@ -139,10 +219,20 @@ function register_tracking_script(): void {
 
 	$env    = get_tracking_script_env();
 	$suffix = ( 'prod' === $env ) ? 'latest' : 'development';
-	$src    = \apply_filters( 'fundy/tracking_script_src', "https://assets.fundy.cloud/fundy-tracking.{$suffix}.js", $env );
+	$src    = \apply_filters( 'fundy/tracking_script_src', "https://assets.fundy.cloud/fundy-wake.{$suffix}.js", $env );
 
 	if ( ! \wp_script_is( 'fundy-tracking-script', 'registered' ) ) {
-		\wp_register_script( 'fundy-tracking-script', $src, [ 'fundy-config' ], null, true );
+		\wp_register_script(
+			'fundy-tracking-script',
+			$src,
+			[ 'fundy-config' ],
+			null,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+				'fetchpriority' => 'low',
+			]
+		);
 	}
 
 	\wp_enqueue_script( 'fundy-tracking-script' );

--- a/inc/head.php
+++ b/inc/head.php
@@ -57,6 +57,7 @@ function add_preload_resources( array $resources ): array {
 			'href'          => $script->src,
 			'as'            => 'script',
 			'fetchpriority' => 'high',
+			'crossorigin'   => 'anonymous',
 		];
 	}
 
@@ -67,6 +68,7 @@ function add_preload_resources( array $resources ): array {
 			'href'          => $style->src,
 			'as'            => 'style',
 			'fetchpriority' => 'high',
+			'crossorigin'   => 'anonymous',
 		];
 	}
 

--- a/inc/head.php
+++ b/inc/head.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace Dekode\Fundraising\Head;
 
 use function Dekode\Fundraising\get_base_url;
+use function Dekode\Fundraising\Assets\should_load_form_assets_in_head;
 
 if ( ! \defined( 'ABSPATH' ) ) {
 	die();
@@ -19,14 +20,66 @@ if ( ! \defined( 'ABSPATH' ) ) {
  * Hooks
  */
 \add_filter( 'wp_resource_hints', __NAMESPACE__ . '\\add_dns_prefetch', 10, 2 );
+\add_filter( 'wp_preload_resources', __NAMESPACE__ . '\\add_preload_resources' );
 
 /**
- * Add DNS prefetch.
+ * Add preconnect hints for the API origin and the asset CDN origin.
  */
 function add_dns_prefetch( array $hints, string $relation_type ): array {
 	if ( 'preconnect' === $relation_type ) {
 		$hints[] = get_base_url();
+		$hints[] = 'https://assets.fundy.cloud';
 	}
 
 	return $hints;
+}
+
+/**
+ * Preload the form script when a form is detected on the current page.
+ *
+ * The form script is enqueued lazily by the [fundy_form] shortcode, which runs
+ * after wp_head. Preloading here lets the browser start fetching in parallel
+ * with HTML parsing instead of waiting until the shortcode is reached.
+ *
+ * Detection is best-effort against the queried post's content. Sites that
+ * render the form via blocks, patterns, widgets, or custom templates can
+ * force preload on via the `fundy/preload/form_script` filter.
+ */
+function add_preload_resources( array $resources ): array {
+	if ( ! should_preload_form_script() ) {
+		return $resources;
+	}
+
+	$script = \wp_scripts()->registered['fundy-form-script'] ?? null;
+
+	if ( $script && ! empty( $script->src ) ) {
+		$resources[] = [
+			'href'          => $script->src,
+			'as'            => 'script',
+			'fetchpriority' => 'high',
+		];
+	}
+
+	$style = \wp_styles()->registered['fundy-form-style'] ?? null;
+
+	if ( $style && ! empty( $style->src ) ) {
+		$resources[] = [
+			'href'          => $style->src,
+			'as'            => 'style',
+			'fetchpriority' => 'high',
+		];
+	}
+
+	return $resources;
+}
+
+/**
+ * Decide whether to preload the form script on this request.
+ *
+ * Defers to the shared detection in the Assets namespace so preload and
+ * head-load decisions stay in sync. The `fundy/preload/form_script` filter
+ * still lets sites override just the preload decision if they need to.
+ */
+function should_preload_form_script(): bool {
+	return (bool) \apply_filters( 'fundy/preload/form_script', should_load_form_assets_in_head() );
 }

--- a/inc/head.php
+++ b/inc/head.php
@@ -35,18 +35,19 @@ function add_dns_prefetch( array $hints, string $relation_type ): array {
 }
 
 /**
- * Preload the form script when a form is detected on the current page.
+ * Preload the form script and stylesheet when a form is detected on the
+ * current page. Gated by the shared `fundy/load_form_assets_in_head` decision
+ * so preload and head-load stay in sync.
  *
- * The form script is enqueued lazily by the [fundy_form] shortcode, which runs
- * after wp_head. Preloading here lets the browser start fetching in parallel
- * with HTML parsing instead of waiting until the shortcode is reached.
- *
- * Detection is best-effort against the queried post's content. Sites that
- * render the form via blocks, patterns, widgets, or custom templates can
- * force preload on via the `fundy/preload/form_script` filter.
+ * The preload entries deliberately omit `crossorigin` so they match the
+ * default no-cors mode of the rendered <script> and <link> tags. If a future
+ * change adds `crossorigin` here it MUST also be added to the rendered tags
+ * (and the CDN must serve `Access-Control-Allow-Origin` on GET responses) —
+ * otherwise the credentials modes diverge and the browser fetches the
+ * resource twice.
  */
 function add_preload_resources( array $resources ): array {
-	if ( ! should_preload_form_script() ) {
+	if ( ! should_load_form_assets_in_head() ) {
 		return $resources;
 	}
 
@@ -57,7 +58,6 @@ function add_preload_resources( array $resources ): array {
 			'href'          => $script->src,
 			'as'            => 'script',
 			'fetchpriority' => 'high',
-			'crossorigin'   => 'anonymous',
 		];
 	}
 
@@ -68,20 +68,8 @@ function add_preload_resources( array $resources ): array {
 			'href'          => $style->src,
 			'as'            => 'style',
 			'fetchpriority' => 'high',
-			'crossorigin'   => 'anonymous',
 		];
 	}
 
 	return $resources;
-}
-
-/**
- * Decide whether to preload the form script on this request.
- *
- * Defers to the shared detection in the Assets namespace so preload and
- * head-load decisions stay in sync. The `fundy/preload/form_script` filter
- * still lets sites override just the preload decision if they need to.
- */
-function should_preload_form_script(): bool {
-	return (bool) \apply_filters( 'fundy/preload/form_script', should_load_form_assets_in_head() );
 }

--- a/src/blocks/donation-receipt/components/Receipt/Receipt.jsx
+++ b/src/blocks/donation-receipt/components/Receipt/Receipt.jsx
@@ -30,6 +30,7 @@ const Receipt = () => {
 				isLoaded: true,
 				isError: true,
 			});
+			return;
 		}
 
 		const params = {

--- a/tests/unit/test-assets.php
+++ b/tests/unit/test-assets.php
@@ -1,6 +1,7 @@
 <?php
 
 use function Dekode\Fundraising\Assets\register_assets;
+use function Dekode\Fundraising\Assets\should_load_form_assets_in_head;
 
 /**
  * Test related to Dekode Fundraising assets on the frontend.
@@ -126,5 +127,144 @@ class TestAssets extends WP_UnitTestCase {
 		$script = $wp_scripts->registered['fundy-tracking-script'];
 		$this->assertContains( 'fundy-config', $script->deps );
 		\delete_option( 'fundy_options' );
+	}
+
+	public function test_detection_returns_false_on_non_singular() {
+		$this->go_to( '/' );
+
+		$this->assertFalse( should_load_form_assets_in_head() );
+	}
+
+	public function test_detection_returns_true_for_post_with_shortcode() {
+		$post_id = self::factory()->post->create( [
+			'post_content' => '[fundy_form id="1"]',
+		] );
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$this->assertTrue( should_load_form_assets_in_head() );
+	}
+
+	public function test_detection_returns_true_for_post_with_block() {
+		$post_id = self::factory()->post->create( [
+			'post_content' => '<!-- wp:fundy/donation-form {"formId":1} /-->',
+		] );
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$this->assertTrue( should_load_form_assets_in_head() );
+	}
+
+	public function test_detection_returns_false_for_post_without_form() {
+		$post_id = self::factory()->post->create( [
+			'post_content' => 'Just some text.',
+		] );
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$this->assertFalse( should_load_form_assets_in_head() );
+	}
+
+	public function test_detection_respects_filter_override() {
+		$this->go_to( '/' );
+
+		\add_filter( 'fundy/load_form_assets_in_head', '__return_true' );
+		$this->assertTrue( should_load_form_assets_in_head() );
+		\remove_filter( 'fundy/load_form_assets_in_head', '__return_true' );
+	}
+
+	public function test_form_script_registers_in_footer_when_detection_fails() {
+		register_assets();
+		\do_action( 'wp_enqueue_scripts' );
+
+		global $wp_scripts;
+		$script = $wp_scripts->registered['fundy-form-script'];
+		$this->assertSame( 1, $script->extra['group'] ?? null );
+	}
+
+	public function test_form_script_registers_in_head_when_detection_passes() {
+		$post_id = self::factory()->post->create( [
+			'post_content' => '[fundy_form id="1"]',
+		] );
+		$this->go_to( \get_permalink( $post_id ) );
+
+		register_assets();
+		\do_action( 'wp_enqueue_scripts' );
+
+		global $wp_scripts;
+		$script = $wp_scripts->registered['fundy-form-script'];
+		$this->assertArrayNotHasKey( 'group', $script->extra );
+		$this->assertTrue( \wp_script_is( 'fundy-form-script', 'enqueued' ) );
+		$this->assertTrue( \wp_style_is( 'fundy-form-style', 'enqueued' ) );
+	}
+
+	public function test_form_script_uses_defer_strategy() {
+		register_assets();
+		\do_action( 'wp_enqueue_scripts' );
+
+		global $wp_scripts;
+		$script = $wp_scripts->registered['fundy-form-script'];
+		$this->assertSame( 'defer', $script->extra['strategy'] ?? null );
+	}
+
+	public function test_preload_resources_added_when_detection_passes() {
+		$post_id = self::factory()->post->create( [
+			'post_content' => '[fundy_form id="1"]',
+		] );
+		$this->go_to( \get_permalink( $post_id ) );
+
+		register_assets();
+		\do_action( 'wp_enqueue_scripts' );
+
+		$resources = \apply_filters( 'wp_preload_resources', [] );
+
+		$script_entry = null;
+		$style_entry  = null;
+		foreach ( $resources as $resource ) {
+			if ( ( $resource['as'] ?? '' ) === 'script' ) {
+				$script_entry = $resource;
+			}
+			if ( ( $resource['as'] ?? '' ) === 'style' ) {
+				$style_entry = $resource;
+			}
+		}
+
+		$this->assertNotNull( $script_entry );
+		$this->assertSame( 'high', $script_entry['fetchpriority'] );
+		$this->assertArrayNotHasKey( 'crossorigin', $script_entry );
+
+		$this->assertNotNull( $style_entry );
+		$this->assertSame( 'high', $style_entry['fetchpriority'] );
+		$this->assertArrayNotHasKey( 'crossorigin', $style_entry );
+	}
+
+	public function test_preload_resources_not_added_when_detection_fails() {
+		register_assets();
+		\do_action( 'wp_enqueue_scripts' );
+
+		$resources = \apply_filters( 'wp_preload_resources', [] );
+
+		foreach ( $resources as $resource ) {
+			$this->assertNotSame( 'fundy-form-script', $resource['href'] ?? null );
+		}
+	}
+
+	public function test_form_style_tag_gains_fetchpriority() {
+		$tag = "<link rel='stylesheet' id='fundy-form-style-css' href='https://assets.fundy.cloud/fundy-forms.latest.css' media='all' />\n";
+
+		$filtered = \apply_filters( 'style_loader_tag', $tag, 'fundy-form-style', 'https://assets.fundy.cloud/fundy-forms.latest.css', 'all' );
+
+		$this->assertStringContainsString( 'fetchpriority="high"', $filtered );
+	}
+
+	public function test_form_style_tag_is_idempotent() {
+		$tag      = "<link rel='stylesheet' fetchpriority=\"high\" href='https://assets.fundy.cloud/x.css' />\n";
+		$filtered = \apply_filters( 'style_loader_tag', $tag, 'fundy-form-style', 'https://assets.fundy.cloud/x.css', 'all' );
+
+		$this->assertSame( 1, \substr_count( $filtered, 'fetchpriority=' ) );
+	}
+
+	public function test_other_style_handles_are_untouched() {
+		$tag      = "<link rel='stylesheet' id='other-css' href='https://example.test/other.css' />\n";
+		$filtered = \apply_filters( 'style_loader_tag', $tag, 'some-other-handle', 'https://example.test/other.css', 'all' );
+
+		$this->assertSame( $tag, $filtered );
 	}
 }


### PR DESCRIPTION
Loads the forms JS script in the `<head>` when possible, improving loading performance. Makes better use of preload/preconnect hints.