### PR TITLE
Bugfix/NGO-1024/Block and REST Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For local development you can edit this constant in the `.wp-env.json` file and 
 * `fundy/enqueue/form_styles` (bool) - Whether to enqueue the Dekode Fundraising form styles. Default is true.
 * `fundy/base_url` (string) - Used to modify the base API URL.
 * `fundy/config/custom_css_url` (string) - Override the custom stylesheet URL injected into Dekode Fundraising forms (the `customCssUrl` key of `window.FundyConfig`). Defaults to the "Custom CSS URL" plugin setting; an empty value omits the key.
+* `fundy/load_form_assets_in_head` (bool) - Force (or prevent) loading the form script/style in `<head>` with preload hints. Defaults to automatic detection on singular pages.
 
 ## Shortcode
 
@@ -39,6 +40,15 @@ You can also define extra parameters to be passed to the frontend by using the `
 You can select a styling variation for the form with the `variation` attribute, matching the `is-style-*` block styles available on the Donation Form block:
 
 ```[fundy_form id='13' variation='compact']```
+
+Note: URL parameter keys are restricted to letters, digits, `_` and `-` (max 64 characters); values are capped at 500 characters. Entries outside those limits are dropped at render time.
+
+## Notes & accepted trade-offs
+
+* **Remote bundles without SRI.** The `fundy-forms`, `fundy-conversion`, and `fundy-tracking` scripts load from `assets.fundy.cloud` under rolling tags (`*.latest.js`), so Subresource Integrity hashes are impossible by design. This is an accepted supply-chain trade-off: the CDN origin is treated as trusted, the same way the Fundy API itself is.
+* **Head-load detection gap.** Early (in-`<head>`) loading of the form assets relies on `has_block()` / `has_shortcode()` against the raw post content, which cannot see forms inside synced patterns or reusable blocks (`core/block` references). Those pages fall back to the standard footer `viewScript` path — the form still renders, just without the preload fast path. Use the `fundy/load_form_assets_in_head` filter to force the fast path for such pages.
+* **Block color supports style the wrapper only.** The form itself renders inside a shadow root with its own styles, so block *background* color shows behind the form; text color would not reach inside the form and is therefore not offered.
+* **Forms REST proxy.** The block editor lists available forms via `GET /wp-json/fundy/v1/forms` (users with `edit_posts`), which calls the Fundy API server-side. The organization API token never leaves PHP.
 
 ## Setup
 

--- a/dekode-fundraising.php
+++ b/dekode-fundraising.php
@@ -119,6 +119,32 @@ function get_base_url(): string {
 }
 
 /**
+ * Sanitize author-supplied form URL parameters.
+ *
+ * The forms runtime appends these to URL query strings, hence the
+ * conservative shape: keys must match [A-Za-z0-9_-]{1,64}, values must be
+ * scalar and are capped at 500 characters. Entries outside those limits are
+ * dropped. Shared by the donation-form block and the [fundy_form] shortcode
+ * so both embed paths enforce the same limits.
+ *
+ * @param array $params Raw parameters, keyed by parameter name.
+ * @return array<string, string> The sanitized parameters.
+ */
+function sanitize_form_url_params( array $params ): array {
+	$sanitized = [];
+
+	foreach ( $params as $key => $value ) {
+		if ( ! \preg_match( '/^[A-Za-z0-9_-]{1,64}$/', (string) $key ) || ! \is_scalar( $value ) ) {
+			continue;
+		}
+
+		$sanitized[ (string) $key ] = \mb_substr( (string) $value, 0, 500 );
+	}
+
+	return $sanitized;
+}
+
+/**
  * If either check fails, display notice and bail.
  */
 if ( ! php_version_check() || ! wp_version_check() ) {
@@ -130,7 +156,7 @@ if ( ! php_version_check() || ! wp_version_check() ) {
  * Load plugin text domain.
  */
 function load_textdomain(): void {
-	\load_plugin_textdomain( 'dekode-fundraising', false, FUNDY_PLUGIN_DIR . 'languages' );
+	\load_plugin_textdomain( 'dekode-fundraising', false, \dirname( \plugin_basename( __FILE__ ) ) . '/languages' );
 }
 \add_action( 'init', __NAMESPACE__ . '\\load_textdomain' );
 

--- a/dekode-fundraising.php
+++ b/dekode-fundraising.php
@@ -130,11 +130,12 @@ if ( ! php_version_check() || ! wp_version_check() ) {
  * Load plugin text domain.
  */
 function load_textdomain(): void {
-	\load_plugin_textdomain( 'dekode-fundraising', false, FUNDY_PLUGIN_DIR . '/languages' );
+	\load_plugin_textdomain( 'dekode-fundraising', false, FUNDY_PLUGIN_DIR . 'languages' );
 }
 \add_action( 'init', __NAMESPACE__ . '\\load_textdomain' );
 
 require_once FUNDY_PLUGIN_DIR . 'inc/settings.php';
+require_once FUNDY_PLUGIN_DIR . 'inc/rest.php';
 require_once FUNDY_PLUGIN_DIR . 'inc/settings-page.php';
 require_once FUNDY_PLUGIN_DIR . 'inc/settings-page-network.php';
 require_once FUNDY_PLUGIN_DIR . 'inc/shortcodes.php';

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -26,6 +26,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
  */
 \add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\register_assets' );
 \add_filter( 'style_loader_tag', __NAMESPACE__ . '\\add_form_style_attrs', 10, 2 );
+\add_filter( 'script_loader_tag', __NAMESPACE__ . '\\add_script_fetchpriority', 10, 2 );
 
 /**
  * Register all assets.
@@ -119,9 +120,8 @@ function register_form_assets(): void {
 			[ 'fundy-config' ],
 			null,
 			[
-				'in_footer'     => ! $load_in_head,
-				'strategy'      => 'defer',
-				'fetchpriority' => 'high',
+				'in_footer' => ! $load_in_head,
+				'strategy'  => 'defer',
 			]
 		);
 	}
@@ -159,6 +159,39 @@ function add_form_style_attrs( string $tag, string $handle ): string {
 	return (string) \preg_replace(
 		'/<link\b([^>]*\bhref=)/',
 		'<link fetchpriority="high"$1',
+		$tag,
+		1
+	);
+}
+
+/**
+ * Add fetchpriority to the rendered remote script tags.
+ *
+ * wp_register_script()'s $args only supports `in_footer` and `strategy` —
+ * a `fetchpriority` key there is silently discarded — so the attribute has
+ * to be filtered onto the tag, mirroring add_form_style_attrs(). The form
+ * bundle's `high` matches its preload hint in inc/head.php.
+ */
+function add_script_fetchpriority( string $tag, string $handle ): string {
+	$priorities = [
+		'fundy-form-script'       => 'high',
+		'fundy-conversion-script' => 'low',
+		'fundy-tracking-script'   => 'low',
+	];
+
+	if ( ! isset( $priorities[ $handle ] ) ) {
+		return $tag;
+	}
+
+	if ( false !== \strpos( $tag, 'fetchpriority=' ) ) {
+		return $tag;
+	}
+
+	// Target the <script ...> that carries src=... — inline before/after
+	// fragments for the same handle have no src attribute.
+	return (string) \preg_replace(
+		'/<script\b([^>]*\bsrc=)/',
+		'<script fetchpriority="' . $priorities[ $handle ] . '"$1',
 		$tag,
 		1
 	);
@@ -227,7 +260,6 @@ function register_conversion_script(): void {
 			[
 				'in_footer' => true,
 				'strategy'  => 'defer',
-				'fetchpriority' => 'low',
 			]
 		);
 	}
@@ -258,7 +290,6 @@ function register_tracking_script(): void {
 			[
 				'in_footer' => true,
 				'strategy'  => 'defer',
-				'fetchpriority' => 'low',
 			]
 		);
 	}

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * REST API.
+ *
+ * @package dekode-fundraising
+ */
+
+declare( strict_types = 1 );
+
+namespace Dekode\Fundraising\REST;
+
+use function Dekode\Fundraising\get_base_url;
+use function Dekode\Fundraising\Settings\get_api_key;
+
+if ( ! \defined( 'ABSPATH' ) ) {
+	die();
+}
+
+/**
+ * Hooks.
+ */
+\add_action( 'rest_api_init', __NAMESPACE__ . '\\register_routes' );
+
+/**
+ * Register REST routes.
+ *
+ * @return void
+ */
+function register_routes(): void {
+	\register_rest_route(
+		'fundy/v1',
+		'/forms',
+		[
+			'methods'             => \WP_REST_Server::READABLE,
+			'callback'            => __NAMESPACE__ . '\\get_forms',
+			'permission_callback' => static function (): bool {
+				return \current_user_can( 'edit_posts' );
+			},
+		]
+	);
+}
+
+/**
+ * Proxy the organization forms list from the Fundy API.
+ *
+ * The API token never leaves the server: the block editor calls this route
+ * (nonce-authenticated, same-origin) and receives only the id/name pairs it
+ * needs to populate the form selector.
+ *
+ * @return \WP_REST_Response|\WP_Error
+ */
+function get_forms(): \WP_REST_Response|\WP_Error {
+	$api_key = get_api_key();
+
+	if ( '' === $api_key ) {
+		return new \WP_Error(
+			'fundy_no_api_token',
+			\__( 'No Fundy API token is configured.', 'dekode-fundraising' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	$response = \wp_remote_get(
+		get_base_url() . '/api/v1/organization/forms',
+		[
+			'headers' => [
+				'Accept'        => 'application/json',
+				'Authorization' => 'Bearer ' . $api_key,
+			],
+			'timeout' => 15,
+		]
+	);
+
+	if ( \is_wp_error( $response ) ) {
+		return new \WP_Error(
+			'fundy_forms_request_failed',
+			\__( 'Could not reach the Fundy API.', 'dekode-fundraising' ),
+			[ 'status' => 502 ]
+		);
+	}
+
+	$code = (int) \wp_remote_retrieve_response_code( $response );
+
+	if ( 200 !== $code ) {
+		return new \WP_Error(
+			'fundy_forms_request_failed',
+			\sprintf(
+				/* translators: %d: HTTP status code returned by the Fundy API. */
+				\__( 'The Fundy API returned an unexpected response (HTTP %d).', 'dekode-fundraising' ),
+				$code
+			),
+			[ 'status' => 502 ]
+		);
+	}
+
+	$data = \json_decode( \wp_remote_retrieve_body( $response ), true );
+
+	if ( ! \is_array( $data ) ) {
+		return new \WP_Error(
+			'fundy_forms_invalid_response',
+			\__( 'The Fundy API returned an invalid response.', 'dekode-fundraising' ),
+			[ 'status' => 502 ]
+		);
+	}
+
+	$forms = [];
+
+	foreach ( $data as $form ) {
+		if ( \is_array( $form ) && isset( $form['id'], $form['name'] ) ) {
+			$forms[] = [
+				'id'   => (int) $form['id'],
+				'name' => (string) $form['name'],
+			];
+		}
+	}
+
+	return \rest_ensure_response( $forms );
+}

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace Dekode\Fundraising\Shortcodes;
 
 use function Dekode\Fundraising\get_base_url;
+use function Dekode\Fundraising\sanitize_form_url_params;
 
 /**
  * Hooks.
@@ -44,15 +45,15 @@ function render_fundy_form_shortcode( array $atts ): string {
 		return '';
 	}
 
-	$params = [];
+	// Author-supplied params share the block path's limits (see
+	// sanitize_form_url_params()); invalid or non-object JSON carries none.
+	$json_params = '';
 
 	if ( ! empty( $atts['params'] ) ) {
-		$params = \json_decode( $atts['params'], true );
+		$decoded = \json_decode( (string) $atts['params'], true );
 
-		if ( \json_last_error() === JSON_ERROR_NONE ) {
-			$atts['params'] = \wp_json_encode( $params );
-		} else {
-			$atts['params'] = '';
+		if ( \is_array( $decoded ) ) {
+			$json_params = (string) \wp_json_encode( sanitize_form_url_params( $decoded ) );
 		}
 	}
 
@@ -88,7 +89,7 @@ function render_fundy_form_shortcode( array $atts ): string {
 		',
 		\esc_attr( (int) $atts['id'] ),
 		\esc_attr( get_base_url() ),
-		\esc_attr( $atts['params'] ),
+		\esc_attr( $json_params ),
 		$variation_attr,
 	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "1.0.0",
 			"devDependencies": {
 				"@playwright/test": "~1.61.0",
+				"@wordpress/a11y": "~4.51.0",
+				"@wordpress/api-fetch": "~7.51.0",
 				"@wordpress/dom-ready": "~4.50.0",
 				"@wordpress/e2e-test-utils-playwright": "~1.50.0",
 				"@wordpress/element": "~6.40.0",
@@ -8070,6 +8072,48 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/a11y": {
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.51.0.tgz",
+			"integrity": "sha512-ophPwL3J31JOA46koDonBz7EL1dMfpKLEj8crD2uCK5IYzvqlYJrLA0o+RfPUUHrbXa51qGBSZ/+Bprb6nao+g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.51.0",
+				"@wordpress/i18n": "^6.24.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/a11y/node_modules/@wordpress/dom-ready": {
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.51.0.tgz",
+			"integrity": "sha512-O/ivmzG+o44CicTW+c17KBXlmjRoVp4VGIyyEQDD52H5YH+gX7i15FuEPk6G2e7Rqz4DCvCS5yD7eY9Zb3z1WA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/api-fetch": {
+			"version": "7.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.51.0.tgz",
+			"integrity": "sha512-kSgBvrGr8eMTcQTA1fIsChg56FKPTdcmkQrpEQjL9uzbmGwPKrru4BdkBFqLSql/PH5fEOjNcY3OSA61+WrJ8g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.24.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/url": "^4.51.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/babel-preset-default": {
 			"version": "8.50.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.50.0.tgz",
@@ -8357,9 +8401,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
-			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
+			"integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8368,14 +8412,14 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
-			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"version": "6.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
+			"integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.50.0",
+				"@wordpress/hooks": "^4.51.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8521,9 +8565,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.50.0.tgz",
-			"integrity": "sha512-bCVLL9YuWfnPNNqlhl4eTKPipjWbJ8MzAlasJ/SR+h979MyeMFjNPapxKqsPqnJOhDEVSdCTkRN/Wa+Xk8qFdw==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.51.0.tgz",
+			"integrity": "sha512-x3FeBDGegBAKveYHNmgZgTbEwuwVMxGouTR2fKP94Myn5PzF5EkZK1CZJrDnfNjzTl73nCwsd4IXACdtYfnnAQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9007,6 +9051,20 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/is-shallow-equal": "^5.50.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/url": {
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.51.0.tgz",
+			"integrity": "sha512-lPjifvknjTfBl8OSS76jsALotvuSWvb5lE8YKeFJ+zwV09q0ZHgQTeMKHrL47DwMl+PlPhmoLrjHav+KLBwTCA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -22014,6 +22072,13 @@
 			"bin": {
 				"regjsparser": "bin/parser"
 			}
+		},
+		"node_modules/remove-accents": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/requestidlecallback": {
 			"version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "~1.61.0",
+		"@wordpress/a11y": "~4.51.0",
+		"@wordpress/api-fetch": "~7.51.0",
 		"@wordpress/dom-ready": "~4.50.0",
 		"@wordpress/e2e-test-utils-playwright": "~1.50.0",
 		"@wordpress/element": "~6.40.0",

--- a/src/blocks/donation-form/block.json
+++ b/src/blocks/donation-form/block.json
@@ -5,13 +5,15 @@
 	"title": "Fundy Form",
 	"description": "Displays a donation/petition form.",
 	"category": "widgets",
-	"textdomain": "fundy",
+	"keywords": ["donation", "fundraising", "petition", "fundy", "form"],
+	"textdomain": "dekode-fundraising",
 	"icon": "clipboard",
+	"example": {},
 	"supports": {
 		"html": false,
 		"color": {
 			"background": true,
-			"text": true
+			"text": false
 		},
 		"spacing": {
 			"margin": true,

--- a/src/blocks/donation-form/block.php
+++ b/src/blocks/donation-form/block.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace Dekode\Fundraising\Blocks\DonationForm;
 
 use function Dekode\Fundraising\get_base_url;
+use function Dekode\Fundraising\sanitize_form_url_params;
 use function Dekode\Fundraising\Settings\get_api_key;
 
 /**
@@ -55,19 +56,17 @@ function render_block( array $attributes ): string {
 		return '';
 	}
 
-	$params = [];
+	$raw_params = [];
 
 	foreach ( (array) ( $attributes['urlParams'] ?? [] ) as $p ) {
-		if ( ! \is_array( $p ) || empty( $p['key'] ) || ! \is_string( $p['key'] ) ) {
-			continue;
+		if ( \is_array( $p ) && ! empty( $p['key'] ) && \is_string( $p['key'] ) ) {
+			$raw_params[ $p['key'] ] = $p['value'] ?? '';
 		}
-
-		if ( ! \preg_match( '/^[A-Za-z0-9_-]{1,64}$/', $p['key'] ) || ! \is_scalar( $p['value'] ?? '' ) ) {
-			continue;
-		}
-
-		$params[ $p['key'] ] = \mb_substr( (string) ( $p['value'] ?? '' ), 0, 500 );
 	}
+
+	// Free-form author input that ends up as URL query parameters in the
+	// forms runtime - hence the shared conservative key shape and length caps.
+	$params = sanitize_form_url_params( $raw_params );
 
 	$json_params = \wp_json_encode( $params );
 
@@ -86,9 +85,9 @@ function render_block( array $attributes ): string {
 		$variation_attr = \sprintf( ' data-variation="%s"', \esc_attr( $matches[1] ) );
 	}
 
-	// The forms runtime replaces the mount's children when it renders, so the
-	// visually-hidden loading text and the noscript fallback below only ever
-	// reach users for whom the remote bundle never executes.
+	// The forms runtime replaces the mount's children when it renders, so
+	// the noscript fallback below only ever reaches users for whom the
+	// remote bundle never executes.
 	return \sprintf( '
 		<div %1$s>
 			<div

--- a/src/blocks/donation-form/block.php
+++ b/src/blocks/donation-form/block.php
@@ -29,8 +29,7 @@ function register_block(): void {
 
 	\wp_set_script_translations( 'fundy-donation-form-editor-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . 'languages' );
 
-	// The API token must never reach the browser — the editor lists forms
-	// through the fundy/v1/forms REST proxy (inc/rest.php), so only the
+	// The API token must never reach the browser so only the
 	// token's existence is exposed here.
 	$settings = [
 		'hasApiToken' => '' !== get_api_key(),
@@ -58,8 +57,6 @@ function render_block( array $attributes ): string {
 
 	$params = [];
 
-	// Free-form author input that ends up as URL query parameters in the
-	// forms runtime - hence the conservative key shape and length caps.
 	foreach ( (array) ( $attributes['urlParams'] ?? [] ) as $p ) {
 		if ( ! \is_array( $p ) || empty( $p['key'] ) || ! \is_string( $p['key'] ) ) {
 			continue;
@@ -72,8 +69,6 @@ function render_block( array $attributes ): string {
 		$params[ $p['key'] ] = \mb_substr( (string) ( $p['value'] ?? '' ), 0, 500 );
 	}
 
-	// The runtime treats '[]' as "no params" already (its data-params parse
-	// ignores non-object JSON), so it is the safe shape when encoding fails.
 	$json_params = \wp_json_encode( $params );
 
 	if ( false === $json_params ) {
@@ -101,7 +96,7 @@ function render_block( array $attributes ): string {
 				data-form-id="%2$s"
 				data-core-url="%3$s"
 				data-params="%4$s"%5$s
-			><span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">%6$s</span><noscript>%7$s</noscript></div>
+			><noscript>%6$s</noscript></div>
 		</div>
 		',
 		\get_block_wrapper_attributes( [
@@ -111,7 +106,6 @@ function render_block( array $attributes ): string {
 		\esc_attr( get_base_url() ),
 		\esc_attr( $json_params ),
 		$variation_attr,
-		\esc_html__( 'Donation form loading…', 'dekode-fundraising' ),
 		\esc_html__( 'This donation form requires JavaScript. Please enable JavaScript in your browser and reload the page.', 'dekode-fundraising' ),
 	);
 }

--- a/src/blocks/donation-form/block.php
+++ b/src/blocks/donation-form/block.php
@@ -27,15 +27,23 @@ function register_block(): void {
 		'render_callback' => __NAMESPACE__ . '\\render_block',
 	] );
 
-	\wp_set_script_translations( 'fundy-donation-form-editor-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . '/languages' );
+	\wp_set_script_translations( 'fundy-donation-form-editor-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . 'languages' );
 
-	\wp_localize_script(
+	// The API token must never reach the browser — the editor lists forms
+	// through the fundy/v1/forms REST proxy (inc/rest.php), so only the
+	// token's existence is exposed here.
+	$settings = [
+		'hasApiToken' => '' !== get_api_key(),
+	];
+
+	if ( \current_user_can( 'manage_options' ) ) {
+		$settings['settingsUrl'] = \admin_url( 'options-general.php?page=fundy_settings_page' );
+	}
+
+	\wp_add_inline_script(
 		'fundy-donation-form-editor-script',
-		'fundySettings',
-		[
-			'baseURL'  => get_base_url(),
-			'apiToken' => get_api_key(),
-		]
+		'window.fundySettings = ' . \wp_json_encode( $settings, \JSON_HEX_TAG | \JSON_HEX_AMP | \JSON_UNESCAPED_SLASHES ) . ';',
+		'before'
 	);
 }
 
@@ -49,12 +57,28 @@ function render_block( array $attributes ): string {
 	}
 
 	$params = [];
-	foreach ( $attributes['urlParams'] as $p ) {
-		if ( !empty( $p['key'] ) ) {
-			$params[ $p['key'] ] = $p['value'] ?? '';
+
+	// Free-form author input that ends up as URL query parameters in the
+	// forms runtime - hence the conservative key shape and length caps.
+	foreach ( (array) ( $attributes['urlParams'] ?? [] ) as $p ) {
+		if ( ! \is_array( $p ) || empty( $p['key'] ) || ! \is_string( $p['key'] ) ) {
+			continue;
 		}
+
+		if ( ! \preg_match( '/^[A-Za-z0-9_-]{1,64}$/', $p['key'] ) || ! \is_scalar( $p['value'] ?? '' ) ) {
+			continue;
+		}
+
+		$params[ $p['key'] ] = \mb_substr( (string) ( $p['value'] ?? '' ), 0, 500 );
 	}
+
+	// The runtime treats '[]' as "no params" already (its data-params parse
+	// ignores non-object JSON), so it is the safe shape when encoding fails.
 	$json_params = \wp_json_encode( $params );
+
+	if ( false === $json_params ) {
+		$json_params = '[]';
+	}
 
 	// Block styles registered by themes land in className as is-style-*.
 	// data-variation carries the chosen style across the shadow boundary so
@@ -67,15 +91,17 @@ function render_block( array $attributes ): string {
 		$variation_attr = \sprintf( ' data-variation="%s"', \esc_attr( $matches[1] ) );
 	}
 
+	// The forms runtime replaces the mount's children when it renders, so the
+	// visually-hidden loading text and the noscript fallback below only ever
+	// reach users for whom the remote bundle never executes.
 	return \sprintf( '
-		<div %s>
+		<div %1$s>
 			<div
 				class="fundy-form fundraising-form"
-				data-form-id="%s"
-				data-core-url="%s"
-				data-button-classes="%s"
-				data-params="%s"%s
-			></div>
+				data-form-id="%2$s"
+				data-core-url="%3$s"
+				data-params="%4$s"%5$s
+			><span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">%6$s</span><noscript>%7$s</noscript></div>
 		</div>
 		',
 		\get_block_wrapper_attributes( [
@@ -83,8 +109,9 @@ function render_block( array $attributes ): string {
 		] ),
 		\esc_attr( $attributes['formId'] ),
 		\esc_attr( get_base_url() ),
-		\esc_attr( 'wp-element-button' ),
 		\esc_attr( $json_params ),
 		$variation_attr,
+		\esc_html__( 'Donation form loading…', 'dekode-fundraising' ),
+		\esc_html__( 'This donation form requires JavaScript. Please enable JavaScript in your browser and reload the page.', 'dekode-fundraising' ),
 	);
 }

--- a/src/blocks/donation-form/edit.js
+++ b/src/blocks/donation-form/edit.js
@@ -1,104 +1,161 @@
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
+import apiFetch from '@wordpress/api-fetch';
 import { useBlockProps } from '@wordpress/block-editor';
-import { useReducer, useEffect } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	Flex,
 	FlexBlock,
 	FlexItem,
+	Notice,
 	Placeholder,
 	SelectControl,
+	Spinner,
 	TextControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * Render the content generation block.
+ * Module-level cache so every block instance in an editor session shares a
+ * single forms request. Reset on failure so a later mount can retry.
+ */
+let formsRequest = null;
+
+function fetchForms() {
+	if (!formsRequest) {
+		formsRequest = apiFetch({ path: '/fundy/v1/forms' }).catch((error) => {
+			formsRequest = null;
+			throw error;
+		});
+	}
+
+	return formsRequest;
+}
+
+/**
+ * Render the donation form block editor UI.
  */
 export default function Edit({
 	attributes: { formId, urlParams = [] },
 	setAttributes,
 }) {
-	const [state, setState] = useReducer((s, a) => ({ ...s, ...a }), {
-		isInitialized: false,
-		isLoaded: false,
-		apiToken: window.fundySettings.apiToken ?? '',
-		baseURL: window.fundySettings.baseURL ?? '',
-		forms: false,
-		error: null,
-	});
+	const blockProps = useBlockProps();
+	const hasApiToken = !!window.fundySettings?.hasApiToken;
+	const settingsUrl = window.fundySettings?.settingsUrl ?? '';
 
-	const { isInitialized, isLoaded, apiToken, baseURL, forms, error } = state;
+	// null = still loading; [] = loaded, none found.
+	const [forms, setForms] = useState(null);
+	const [error, setError] = useState(null);
 
-	// Initialize
+	// Stable per-row keys for the urlParams repeater, so removing a middle
+	// row doesn't re-associate DOM/focus with the wrong row. Attributes only
+	// store {key, value}; identity lives here for the session.
+	const rowIds = useRef([]);
+	const nextRowId = useRef(0);
+
+	while (rowIds.current.length < urlParams.length) {
+		rowIds.current.push(`param-${nextRowId.current++}`);
+	}
+
+	if (rowIds.current.length > urlParams.length) {
+		rowIds.current = rowIds.current.slice(0, urlParams.length);
+	}
+
 	useEffect(() => {
-		if (false === isInitialized && apiToken && baseURL) {
-			setState({ isInitialized: true });
+		if (!hasApiToken) {
+			return undefined;
 		}
-	}, [isInitialized, apiToken, baseURL]);
 
-	// Fetch forms
-	useEffect(() => {
-		if (baseURL && apiToken) {
-			fetch(`${baseURL}/api/v1/organization/forms`, {
-				method: 'GET',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: 'Bearer ' + apiToken,
-				},
-			})
-				.then((response) => {
-					if (!response.ok) {
-						throw new Error('Network response was not ok.');
-					}
-					return response.json();
-				})
-				.then((data) => {
-					const options = data.map((form) => ({
-						value: form.id,
+		let cancelled = false;
+
+		fetchForms()
+			.then((data) => {
+				if (cancelled) {
+					return;
+				}
+
+				setForms(
+					data.map((form) => ({
+						value: String(form.id),
 						label: form.name,
-					}));
+					})),
+				);
+				setError(null);
+			})
+			.catch((err) => {
+				if (cancelled) {
+					return;
+				}
 
-					setState({
-						isLoaded: true,
-						forms: options,
-						error: null,
-					});
+				const message =
+					err?.message ||
+					__('Unable to load forms.', 'dekode-fundraising');
 
-					// If no form is saved, set first form as selected.
-					if (!formId && options.length) {
-						setAttributes({
-							formId: parseInt(options[0].value, 10),
-						});
-					}
-				})
-				.catch((err) => {
-					setState({
-						error:
-							'There has been a problem with your fetch operation: ' +
-							err,
-					});
-				});
-		}
-	}, [baseURL, apiToken, formId, setAttributes]);
+				setError(message);
+				speak(message, 'assertive');
+			});
 
-	/* eslint-disable react-hooks/rules-of-hooks */
-	if (!apiToken) {
+		return () => {
+			cancelled = true;
+		};
+	}, [hasApiToken]);
+
+	if (!hasApiToken) {
 		return (
-			<div {...useBlockProps()}>
+			<div {...blockProps}>
 				<Placeholder
-					instructions={__(
-						'Please set an API Token on the plugin settings page.',
-						'dekode-fundraising',
+					label={__('Fundy Form', 'dekode-fundraising')}
+					instructions={
+						settingsUrl
+							? __(
+									'Set an API token on the plugin settings page to select a form.',
+									'dekode-fundraising',
+								)
+							: __(
+									'An API token is required. Ask a site administrator to configure the Dekode Fundraising plugin.',
+									'dekode-fundraising',
+								)
+					}
+				>
+					{settingsUrl && (
+						<Button variant="primary" href={settingsUrl}>
+							{__('Open settings', 'dekode-fundraising')}
+						</Button>
 					)}
-				/>
+				</Placeholder>
 			</div>
 		);
 	}
 
-	const hasForms = forms && forms.length > 0;
+	const isLoaded = null !== forms;
+	const hasForms = isLoaded && forms.length > 0;
+	const isStale =
+		isLoaded &&
+		formId > 0 &&
+		!forms.some((form) => Number(form.value) === formId);
+
+	const formOptions = [
+		{
+			label: __('— Select a form —', 'dekode-fundraising'),
+			value: '0',
+			disabled: true,
+		},
+		...(forms ?? []),
+	];
+
+	if (isStale) {
+		formOptions.push({
+			label: sprintf(
+				/* translators: %d: saved form ID. */
+				__('Form ID %d (missing)', 'dekode-fundraising'),
+				formId,
+			),
+			value: String(formId),
+		});
+	}
 
 	/**
 	 * Repeater handlers
@@ -117,42 +174,83 @@ export default function Edit({
 	};
 
 	const removeParam = (index) => {
+		rowIds.current = rowIds.current.filter((_, i) => i !== index);
 		const updated = urlParams.filter((_, i) => i !== index);
 		setAttributes({ urlParams: updated });
 	};
 
 	return (
-		<div {...useBlockProps()}>
-			<Placeholder label={__('Dekode Fundraising Form', 'dekode-fundraising')} isColumnLayout>
+		<div {...blockProps} aria-busy={!isLoaded && !error}>
+			<Placeholder
+				label={__('Fundy Form', 'dekode-fundraising')}
+				isColumnLayout
+			>
 				<SelectControl
 					label={__('Select a Form', 'dekode-fundraising')}
-					value={formId}
-					className="fundy-form"
-					options={forms || [{ label: '', value: '' }]}
+					value={String(formId)}
+					options={formOptions}
 					onChange={(value) =>
 						setAttributes({ formId: parseInt(value, 10) })
 					}
-					disabled={!isLoaded}
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 
-				{!hasForms && (
-					<p>
+				{!isLoaded && !error && (
+					<Flex justify="flex-start">
+						<Spinner />
+						<span>
+							{__('Loading forms…', 'dekode-fundraising')}
+						</span>
+					</Flex>
+				)}
+
+				{isLoaded && !hasForms && (
+					<Notice status="warning" isDismissible={false}>
 						{__(
 							'No forms found. Please create a Form on your Dekode Fundraising account first.',
 							'dekode-fundraising',
 						)}
-					</p>
+					</Notice>
 				)}
 
-				{!isLoaded && <p>{__('Loading…', 'dekode-fundraising')}</p>}
-				{error && <p>{'Error: ' + error}</p>}
+				{isStale && (
+					<Notice status="warning" isDismissible={false}>
+						{sprintf(
+							/* translators: %d: saved form ID. */
+							__(
+								'The selected form (ID %d) no longer exists in your Fundy account. Please choose another form.',
+								'dekode-fundraising',
+							),
+							formId,
+						)}
+					</Notice>
+				)}
 
-				<div className="fundy-form-params">
-					<h4>{__('Default URL Parameters (Optional)', 'dekode-fundraising')}</h4>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{sprintf(
+							/* translators: %s: error message. */
+							__(
+								'Could not load forms: %s',
+								'dekode-fundraising',
+							),
+							error,
+						)}
+					</Notice>
+				)}
+
+				<fieldset className="fundy-form-params">
+					<legend>
+						{__(
+							'Default URL Parameters (Optional)',
+							'dekode-fundraising',
+						)}
+					</legend>
 
 					<div style={{ marginTop: '1em' }}>
 						{urlParams.map((param, index) => (
-							<Flex key={`param-${index}`}>
+							<Flex key={rowIds.current[index]}>
 								<FlexBlock>
 									<TextControl
 										label={__('Key', 'dekode-fundraising')}
@@ -160,22 +258,48 @@ export default function Edit({
 										onChange={(val) =>
 											updateParam(index, 'key', val)
 										}
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
 									/>
 								</FlexBlock>
 								<FlexBlock>
 									<TextControl
-										label={__('Value', 'dekode-fundraising')}
+										label={__(
+											'Value',
+											'dekode-fundraising',
+										)}
 										value={param.value}
 										onChange={(val) =>
 											updateParam(index, 'value', val)
 										}
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
 									/>
 								</FlexBlock>
 								<FlexItem>
 									<Button
 										isDestructive
 										onClick={() => removeParam(index)}
-										style={{ marginTop: '14px' }}
+										style={{ marginTop: '24px' }}
+										aria-label={
+											param.key
+												? sprintf(
+														/* translators: %s: parameter key. */
+														__(
+															'Remove parameter "%s"',
+															'dekode-fundraising',
+														),
+														param.key,
+													)
+												: sprintf(
+														/* translators: %d: row number. */
+														__(
+															'Remove parameter %d',
+															'dekode-fundraising',
+														),
+														index + 1,
+													)
+										}
 									>
 										{__('Remove', 'dekode-fundraising')}
 									</Button>
@@ -186,9 +310,8 @@ export default function Edit({
 							{__('Add Parameter', 'dekode-fundraising')}
 						</Button>
 					</div>
-				</div>
+				</fieldset>
 			</Placeholder>
 		</div>
 	);
-	/* eslint-enable react-hooks/rules-of-hooks */
 }

--- a/src/blocks/donation-form/editor.js
+++ b/src/blocks/donation-form/editor.js
@@ -6,10 +6,10 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import name from './block.json';
+import metadata from './block.json';
 import edit from './edit';
 
-registerBlockType(name, {
+registerBlockType(metadata, {
 	edit,
 	save: () => null,
 });

--- a/src/blocks/donation-receipt/block.json
+++ b/src/blocks/donation-receipt/block.json
@@ -5,13 +5,13 @@
 	"title": "Donation Receipt",
 	"description": "Displays a donation receipt on a thank you page.",
 	"category": "widgets",
-	"textdomain": "fundy",
+	"textdomain": "dekode-fundraising",
 	"icon": "clipboard",
 	"supports": {
 		"html": false,
 		"color": {
 			"background": true,
-			"text": true
+			"text": false
 		},
 		"spacing": {
 			"margin": true,

--- a/src/blocks/donation-receipt/block.php
+++ b/src/blocks/donation-receipt/block.php
@@ -26,8 +26,8 @@ function register_block(): void {
 		'render_callback' => __NAMESPACE__ . '\\render_block',
 	] );
 
-	\wp_set_script_translations( 'fundy-donation-receipt-editor-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . '/languages' );
-	\wp_set_script_translations( 'fundy-donation-receipt-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . '/languages' );
+	\wp_set_script_translations( 'fundy-donation-receipt-editor-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . 'languages' );
+	\wp_set_script_translations( 'fundy-donation-receipt-script', 'dekode-fundraising', \FUNDY_PLUGIN_DIR . 'languages' );
 
 	if (! \is_admin() ) {
 		\wp_localize_script(

--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -32,7 +32,7 @@ async function globalSetup(config) {
 		await requestUtils.deactivatePlugin(slug);
 	}
 
-	await requestUtils.activatePlugin('fundy-extension-wp/plugin');
+	await requestUtils.activatePlugin('fundy-extension-wp/dekode-fundraising');
 
 	await requestContext.dispose();
 }

--- a/tests/e2e/config/playwright.config.ts
+++ b/tests/e2e/config/playwright.config.ts
@@ -52,7 +52,7 @@ const config = defineConfig({
 	],
 	webServer: {
 		...baseConfig.webServer,
-		command: 'npm run env:start',
+		command: 'npm run wp-env start',
 	},
 });
 

--- a/tests/e2e/test-01-block-form.ts
+++ b/tests/e2e/test-01-block-form.ts
@@ -10,8 +10,9 @@ test.describe('Donation form block', () => {
 	test('Is registered correctly', async ({ editor, page }) => {
 		await editor.insertBlock({ name: 'fundy/donation-form' });
 
+		// No auto-select: inserting the block must not commit a form choice.
 		expect(await editor.getEditedPostContent()).toBe(
-			'<!-- wp:fundy/donation-form {"formId":100} /-->',
+			'<!-- wp:fundy/donation-form /-->',
 		);
 	});
 
@@ -23,10 +24,11 @@ test.describe('Donation form block', () => {
 			.locator('role=button[name="Add default block"i]')
 			.click();
 		await page.keyboard.type('/donation');
-		await page.waitForTimeout(250);
-		await page.keyboard.press('Enter');
+		// Select the block by name — the autocompleter's result order is not
+		// part of the contract.
+		await page.getByRole('option', { name: 'Fundy Form' }).click();
 		expect(await editor.getEditedPostContent()).toBe(
-			'<!-- wp:fundy/donation-form {"formId":100} /-->',
+			'<!-- wp:fundy/donation-form /-->',
 		);
 	});
 

--- a/tests/e2e/test-01-block-receipt.ts
+++ b/tests/e2e/test-01-block-receipt.ts
@@ -21,9 +21,9 @@ test.describe('Donation receipt block', () => {
 			.locator('role=button[name="Add default block"i]')
 			.click();
 		await page.keyboard.type('/donation');
-		await page.waitForTimeout(250);
-		await page.keyboard.press('ArrowDown');
-		await page.keyboard.press('Enter');
+		// Select the block by name — the autocompleter's result order is not
+		// part of the contract.
+		await page.getByRole('option', { name: 'Donation Receipt' }).click();
 		expect(await editor.getEditedPostContent()).toBe(
 			'<!-- wp:fundy/donation-receipt /-->',
 		);

--- a/tests/e2e/utils/mock.ts
+++ b/tests/e2e/utils/mock.ts
@@ -1,38 +1,29 @@
 import { type Page } from '@playwright/test';
 
 async function mockAjaxRequests(page: Page) {
-	await page.route('**/*/api/v1/organization/forms', async (route) => {
-		await route.fulfill({
-			status: 200,
-			contentType: 'application/json',
-			json: [
-				{
-					id: 100,
-					created_at: '2025-05-28T13:07:52.000000Z',
-					updated_at: '2025-05-28T13:07:52.000000Z',
-					name: 'Test - basic-all-positives',
-					is_active: 1,
-					disabled_at: null,
-					campaign_id: 1,
-					locked_by: null,
-					locked_at: null,
-					public_id: 'a42f53h-3bc9-11f0-b3f9-3eca9b8s4d74',
-				},
-				{
-					id: 101,
-					created_at: '2025-05-28T13:07:52.000000Z',
-					updated_at: '2025-05-28T13:07:52.000000Z',
-					name: 'Test - basic-all-negatives',
-					is_active: 1,
-					disabled_at: null,
-					campaign_id: 1,
-					locked_by: null,
-					locked_at: null,
-					public_id: 'a42f82h-3bc9-11f0-b3f9-a9s5df46s8',
-				},
-			],
-		});
-	});
+	// Match both permalink styles for the plugin's forms REST proxy:
+	// /wp-json/fundy/v1/forms and ?rest_route=/fundy/v1/forms.
+	await page.route(
+		(url) =>
+			url.pathname.includes('/fundy/v1/forms') ||
+			url.search.includes('fundy/v1/forms'),
+		async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				json: [
+					{
+						id: 100,
+						name: 'Test - basic-all-positives',
+					},
+					{
+						id: 101,
+						name: 'Test - basic-all-negatives',
+					},
+				],
+			});
+		},
+	);
 }
 
 export { mockAjaxRequests };

--- a/tests/unit/test-assets.php
+++ b/tests/unit/test-assets.php
@@ -295,4 +295,43 @@ class TestAssets extends WP_UnitTestCase {
 
 		$this->assertSame( $tag, $filtered );
 	}
+
+	public function test_form_script_tag_gains_high_fetchpriority() {
+		$tag = "<script src='https://assets.fundy.cloud/fundy-forms.latest.js' id='fundy-form-script-js' defer data-wp-strategy='defer'></script>\n";
+
+		$filtered = \apply_filters( 'script_loader_tag', $tag, 'fundy-form-script', 'https://assets.fundy.cloud/fundy-forms.latest.js' );
+
+		$this->assertStringContainsString( 'fetchpriority="high"', $filtered );
+	}
+
+	public function test_conversion_and_tracking_script_tags_gain_low_fetchpriority() {
+		foreach ( [ 'fundy-conversion-script', 'fundy-tracking-script' ] as $handle ) {
+			$tag = "<script src='https://assets.fundy.cloud/x.js' id='{$handle}-js' defer></script>\n";
+
+			$filtered = \apply_filters( 'script_loader_tag', $tag, $handle, 'https://assets.fundy.cloud/x.js' );
+
+			$this->assertStringContainsString( 'fetchpriority="low"', $filtered );
+		}
+	}
+
+	public function test_form_script_tag_fetchpriority_is_idempotent() {
+		$tag      = "<script fetchpriority=\"high\" src='https://assets.fundy.cloud/x.js'></script>\n";
+		$filtered = \apply_filters( 'script_loader_tag', $tag, 'fundy-form-script', 'https://assets.fundy.cloud/x.js' );
+
+		$this->assertSame( 1, \substr_count( $filtered, 'fetchpriority=' ) );
+	}
+
+	public function test_other_script_handles_are_untouched() {
+		$tag      = "<script src='https://example.test/other.js' id='other-js'></script>\n";
+		$filtered = \apply_filters( 'script_loader_tag', $tag, 'some-other-handle', 'https://example.test/other.js' );
+
+		$this->assertSame( $tag, $filtered );
+	}
+
+	public function test_form_script_inline_fragment_is_untouched() {
+		$tag      = "<script id='fundy-form-script-js-before'>window.x = 1;</script>\n";
+		$filtered = \apply_filters( 'script_loader_tag', $tag, 'fundy-form-script', '' );
+
+		$this->assertStringNotContainsString( 'fetchpriority=', $filtered );
+	}
 }

--- a/tests/unit/test-blocks.php
+++ b/tests/unit/test-blocks.php
@@ -85,4 +85,97 @@ class TestDonationFormBlock extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( 'data-variation', $html );
 	}
+
+	public function test_returns_empty_string_without_form_id() {
+		$this->assertSame( '', $this->render_donation_form( [
+			'formId'    => 0,
+			'urlParams' => [],
+		] ) );
+	}
+
+	public function test_data_button_classes_is_not_emitted() {
+		$html = $this->render_donation_form( [
+			'formId'    => 1,
+			'urlParams' => [],
+		] );
+
+		$this->assertStringNotContainsString( 'data-button-classes', $html );
+	}
+
+	public function test_fallback_content_is_present() {
+		$html = $this->render_donation_form( [
+			'formId'    => 1,
+			'urlParams' => [],
+		] );
+
+		$this->assertStringContainsString( '<noscript>', $html );
+		$this->assertStringContainsString( 'Donation form loading', $html );
+	}
+
+	/**
+	 * Pull the data-params JSON back out of the rendered attribute.
+	 */
+	private function extract_params( string $html ): array {
+		$this->assertSame( 1, \preg_match( '/data-params="([^"]*)"/', $html, $matches ) );
+
+		$decoded = \json_decode( \html_entity_decode( $matches[1], ENT_QUOTES ), true );
+
+		return \is_array( $decoded ) ? $decoded : [];
+	}
+
+	public function test_valid_url_params_are_rendered() {
+		$html = $this->render_donation_form( [
+			'formId'    => 1,
+			'urlParams' => [
+				[
+					'key'   => 'utm_source',
+					'value' => 'newsletter',
+				],
+			],
+		] );
+
+		$this->assertSame( [ 'utm_source' => 'newsletter' ], $this->extract_params( $html ) );
+	}
+
+	public function test_invalid_url_param_keys_are_dropped() {
+		$html = $this->render_donation_form( [
+			'formId'    => 1,
+			'urlParams' => [
+				[
+					'key'   => 'has space',
+					'value' => 'x',
+				],
+				[
+					'key'   => '<script>',
+					'value' => 'x',
+				],
+				[
+					'key'   => \str_repeat( 'a', 65 ),
+					'value' => 'x',
+				],
+				[
+					'key'   => 'valid-key',
+					'value' => 'kept',
+				],
+			],
+		] );
+
+		$this->assertSame( [ 'valid-key' => 'kept' ], $this->extract_params( $html ) );
+	}
+
+	public function test_url_param_values_are_length_capped() {
+		$html = $this->render_donation_form( [
+			'formId'    => 1,
+			'urlParams' => [
+				[
+					'key'   => 'long',
+					'value' => \str_repeat( 'v', 600 ),
+				],
+			],
+		] );
+
+		$params = $this->extract_params( $html );
+
+		$this->assertSame( 500, \strlen( $params['long'] ) );
+	}
 }

--- a/tests/unit/test-rest.php
+++ b/tests/unit/test-rest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Tests for the fundy/v1/forms REST proxy.
+ */
+class TestRestForms extends WP_UnitTestCase {
+	/**
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		\do_action( 'rest_api_init' );
+	}
+
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		\delete_option( 'fundy_options' );
+
+		parent::tear_down();
+	}
+
+	private function dispatch(): WP_REST_Response {
+		return $this->server->dispatch( new WP_REST_Request( 'GET', '/fundy/v1/forms' ) );
+	}
+
+	private function set_api_key( string $key ): void {
+		\update_option( 'fundy_options', [ 'api_key' => $key ] );
+	}
+
+	private function as_editor(): void {
+		\wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+	}
+
+	public function test_route_is_registered() {
+		$this->assertArrayHasKey( '/fundy/v1/forms', $this->server->get_routes() );
+	}
+
+	public function test_logged_out_requests_are_rejected() {
+		\wp_set_current_user( 0 );
+
+		$this->assertSame( 401, $this->dispatch()->get_status() );
+	}
+
+	public function test_users_without_edit_posts_are_rejected() {
+		\wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertSame( 403, $this->dispatch()->get_status() );
+	}
+
+	public function test_missing_api_key_returns_error() {
+		$this->as_editor();
+
+		$response = $this->dispatch();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'fundy_no_api_token', $response->get_data()['code'] );
+	}
+
+	public function test_forms_are_proxied_and_mapped() {
+		$this->as_editor();
+		$this->set_api_key( 'secret-token' );
+
+		$seen = [];
+
+		\add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( &$seen ) {
+				$seen['url']  = $url;
+				$seen['auth'] = $args['headers']['Authorization'] ?? '';
+
+				return [
+					'headers'  => [],
+					'body'     => \wp_json_encode( [
+						[
+							'id'     => 7,
+							'name'   => 'Main form',
+							'secret' => 'must-not-leak',
+						],
+						[
+							'id'   => '9',
+							'name' => 'Petition',
+						],
+						'not-a-form',
+						[ 'name' => 'missing id' ],
+					] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			},
+			10,
+			3
+		);
+
+		$response = $this->dispatch();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			[
+				[
+					'id'   => 7,
+					'name' => 'Main form',
+				],
+				[
+					'id'   => 9,
+					'name' => 'Petition',
+				],
+			],
+			$response->get_data()
+		);
+		$this->assertStringEndsWith( '/api/v1/organization/forms', $seen['url'] );
+		$this->assertSame( 'Bearer secret-token', $seen['auth'] );
+	}
+
+	public function test_upstream_error_status_maps_to_bad_gateway() {
+		$this->as_editor();
+		$this->set_api_key( 'secret-token' );
+
+		\add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'headers'  => [],
+					'body'     => '',
+					'response' => [
+						'code'    => 500,
+						'message' => 'Internal Server Error',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+		);
+
+		$this->assertSame( 502, $this->dispatch()->get_status() );
+	}
+
+	public function test_upstream_transport_failure_maps_to_bad_gateway() {
+		$this->as_editor();
+		$this->set_api_key( 'secret-token' );
+
+		\add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'http_request_failed', 'timeout' );
+			}
+		);
+
+		$this->assertSame( 502, $this->dispatch()->get_status() );
+	}
+
+	public function test_invalid_upstream_body_maps_to_bad_gateway() {
+		$this->as_editor();
+		$this->set_api_key( 'secret-token' );
+
+		\add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'headers'  => [],
+					'body'     => 'not json',
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+		);
+
+		$this->assertSame( 502, $this->dispatch()->get_status() );
+	}
+}

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -28,4 +28,48 @@ class TestShortcodes extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'fundraising-form', $html );
 		$this->assertStringNotContainsString( 'data-variation', $html );
 	}
+
+	/**
+	 * Pull the data-params JSON back out of the rendered attribute.
+	 */
+	private function extract_params( string $html ): array {
+		$this->assertSame( 1, \preg_match( '/data-params="([^"]*)"/', $html, $matches ) );
+
+		$decoded = \json_decode( \html_entity_decode( $matches[1], ENT_QUOTES ), true );
+
+		return \is_array( $decoded ) ? $decoded : [];
+	}
+
+	public function test_valid_params_are_rendered() {
+		$html = \do_shortcode( '[fundy_form id="1" params=\'{"utm_source":"newsletter"}\']' );
+
+		$this->assertSame( [ 'utm_source' => 'newsletter' ], $this->extract_params( $html ) );
+	}
+
+	public function test_invalid_param_keys_are_dropped() {
+		$json = '{"has space":"x","<script>":"x","' . \str_repeat( 'a', 65 ) . '":"x","valid-key":"kept"}';
+		$html = \do_shortcode( "[fundy_form id='1' params='" . $json . "']" );
+
+		$this->assertSame( [ 'valid-key' => 'kept' ], $this->extract_params( $html ) );
+	}
+
+	public function test_param_values_are_length_capped() {
+		$html = \do_shortcode( '[fundy_form id="1" params=\'{"long":"' . \str_repeat( 'v', 600 ) . '"}\']' );
+
+		$params = $this->extract_params( $html );
+
+		$this->assertSame( 500, \strlen( $params['long'] ) );
+	}
+
+	public function test_invalid_params_json_is_dropped() {
+		$html = \do_shortcode( '[fundy_form id="1" params="not json"]' );
+
+		$this->assertStringContainsString( 'data-params=""', $html );
+	}
+
+	public function test_non_object_params_json_is_dropped() {
+		$html = \do_shortcode( '[fundy_form id="1" params="123"]' );
+
+		$this->assertStringContainsString( 'data-params=""', $html );
+	}
 }


### PR DESCRIPTION
Fixes the findings from a critical review of the `fundy/donation-form` block. The headline change is security: the organization API token was printed into every block-editor page via `wp_localize_script`, visible to any user who can open the editor. The editor now lists forms through a new server-side REST proxy (`GET /wp-json/fundy/v1/forms`, `edit_posts` capability) and the token never leaves PHP - the editor script only learns whether a token exists. The `edit.js` refactor that consumes the proxy also removes the silent auto-select on insert (replaced with an explicit "Select a form" placeholder and a warning when a saved form no longer exists), fixes a suppressed rules-of-hooks violation, shares one forms request across block instances, and closes the editor's main accessibility gaps (announced errors, stable repeater row identity, labelled Remove buttons, `fieldset`/`legend` structure).

Alongside that, a set of smaller correctness and performance fixes: both blocks' `block.json` textdomain corrected from `fundy` to `dekode-fundraising` (title/description were untranslatable), inserter `keywords`/`example` added, `color.text` support dropped (it cannot reach inside the shadow-rooted form), and the unsupported `fetchpriority` key in `wp_register_script()` args - silently discarded by WordPress - replaced with a `script_loader_tag` filter so the form bundle actually ships `fetchpriority="high"` to match its preload hint. The front-end mount now includes a  `noscript` fallback, `urlParams` are sanitized at render time (conservative key shape, length caps), and the dead `data-button-classes` attribute (read by nothing in the forms runtime) is gone.

Verification: new PHPUnit suites cover the REST proxy and render changes (ready for when `test:php`'s PHPUnit 10 incompatibility is resolved), and the e2e suite - previously unrunnable - now passes 10/11 after fixing the stale plugin slug in global-setup and the dead `env:start` reference in the Playwright config, updating the mock to the proxy route, and making the `/donation` shortcut specs order-independent. The remaining e2e failure is a pre-existing stale settings spec, unrelated to this branch. Accepted trade-offs (no SRI on rolling CDN tags, the head-load detection gap for synced patterns) are now documented in the README. Note for local e2e/test:php runs: the tests environment is disabled in `.wp-env.json`; re-enable it locally with a gitignored `.wp-env.override.json` containing `{ "testsEnvironment": true }`.